### PR TITLE
[feature] keep api hot for faster api calls

### DIFF
--- a/endpoints/status/handler.js
+++ b/endpoints/status/handler.js
@@ -3,6 +3,14 @@ const endpoint = require('serverless-endpoint')
 const Redis = require('./redis')
 
 function status (req, res) {
+    /** Immediate response for WarmUP plugin */
+  if (req.getOriginalRequest().event.source === 'serverless-plugin-warmup') {
+    console.log('We are keeping this warm!')
+    // Escape request
+    return res.send(null)
+  }
+
+
   const server = new Redis()
   const realmdata = new Redis({ prefix: 'realmdata' })
   let lastUpdated = null

--- a/endpoints/status/package.json
+++ b/endpoints/status/package.json
@@ -12,5 +12,8 @@
     "flat": "4.0.0",
     "redis": "2.8.0",
     "serverless-endpoint": "0.1.0"
+  },
+  "devDependencies": {
+    "serverless-plugin-warmup": "3.3.0-rc.1"
   }
 }

--- a/endpoints/status/serverless.yml
+++ b/endpoints/status/serverless.yml
@@ -2,12 +2,27 @@ service: status
 
 plugins:
   - serverless-offline
+  - serverless-plugin-warmup
 
 custom: ${file(../.serverless.yml)}
 
 provider:
   name: aws
   runtime: nodejs6.10
+  iamRoleStatements:
+    - Effect: 'Allow'
+      Action:
+        - 'lambda:InvokeFunction'
+      Resource:
+      - Fn::Join:
+        - ':'
+        - - arn:aws:lambda
+          - Ref: AWS::Region
+          - Ref: AWS::AccountId
+          - function:${self:service}-${opt:stage, self:provider.stage}-*
+  vpc:
+    securityGroupids: ${self:custom:securityGroupids}
+    subnetIds: ${self:custom:subnetIds}
   environment:
     ENVIRONMENT: ${opt:stage}
     REDIS_HOST: ${env:REDIS_HOST, self:custom.${opt:stage}.REDIS_HOST}
@@ -17,11 +32,10 @@ region: us-east-1
 
 functions:
   status:
+    warmup:
+      - production
     handler: handler.status
-    memory: 64mb
-    vpc:
-      securityGroupids: ${self:custom:securityGroupids}
-      subnetIds: ${self:custom:subnetIds}
+    memory: 128
     events:
       - http:
           path: status


### PR DESCRIPTION
Keep lambda warmer than normal 🌶.  This will call the api every 5 mins to keep around at least one warm container for faster api calls.